### PR TITLE
Added methods to send Images and CodeSnippets to users and channels

### DIFF
--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackSession.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackSession.java
@@ -3,6 +3,7 @@ package com.ullink.slack.simpleslackapi;
 import com.ullink.slack.simpleslackapi.listeners.*;
 import com.ullink.slack.simpleslackapi.replies.*;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
@@ -88,6 +89,14 @@ public interface SlackSession {
     SlackMessageHandle<SlackMessageReply> sendFileToUser(SlackUser user, byte [] data, String fileName);
 
     SlackMessageHandle<SlackMessageReply> sendFileToUser(String userName, byte [] data, String fileName);
+
+    public SlackMessageHandle<SlackMessageReply> sendCodeSnippet(SlackChannel channel, String title, String snippet, String language);
+
+    public SlackMessageHandle<SlackMessageReply> sendCodeSnippetToUser(SlackUser user, String title, String snippet, String language);
+
+    public SlackMessageHandle<SlackMessageReply> sendImage(SlackChannel channel, String title, File img);
+
+    public SlackMessageHandle<SlackMessageReply> sendImageToUser(SlackUser user, String title, File img);
 
     SlackMessageHandle<SlackMessageReply> sendMessageToUser(SlackUser user, SlackPreparedMessage preparedMessage);
 

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackSessionWrapper.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackSessionWrapper.java
@@ -1,5 +1,6 @@
 package com.ullink.slack.simpleslackapi;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
@@ -231,6 +232,26 @@ public class SlackSessionWrapper implements SlackSession
     public SlackMessageHandle<SlackMessageReply> sendFileToUser(String userName, byte[] data, String fileName)
     {
         return delegate.sendFileToUser(userName, data, fileName);
+    }
+
+    @Override
+    public SlackMessageHandle<SlackMessageReply> sendCodeSnippet(SlackChannel channel, String title, String snippet, String language) {
+        return delegate.sendCodeSnippet(channel, title, snippet, language);
+    }
+
+    @Override
+    public SlackMessageHandle<SlackMessageReply> sendCodeSnippetToUser(SlackUser user, String title, String snippet, String language) {
+        return delegate.sendCodeSnippetToUser(user, title, snippet, language);
+    }
+
+    @Override
+    public SlackMessageHandle<SlackMessageReply> sendImage(SlackChannel channel, String title, File img) {
+        return delegate.sendImage(channel, title, img);
+    }
+
+    @Override
+    public SlackMessageHandle<SlackMessageReply> sendImageToUser(SlackUser user, String title, File img) {
+        return delegate.sendImageToUser(user, title, img);
     }
 
     @Override public SlackMessageHandle<SlackMessageReply> sendMessageToUser(SlackUser user, SlackPreparedMessage preparedMessage)

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
@@ -671,17 +671,12 @@ class SlackWebSocketSessionImpl extends AbstractSlackSessionImpl implements Slac
         arguments.put("title", title);
 
         // convert file to byte []
-        ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        byte[] buf = new byte[1024];
-        try (FileInputStream fis = new FileInputStream(img)) {
-            for (int readNum; (readNum = fis.read(buf)) != -1;) {
-                //Writes to this byte array output stream
-                bos.write(buf, 0, readNum);
-            }
-        } catch (IOException ex) {
+        byte[] imgBytes = new byte[(int) img.length()];
+        try (InputStream is = new FileInputStream(img)) {
+            is.read(imgBytes);
+        } catch (IOException e) {
+            e.printStackTrace();
         }
-
-        byte[] imgBytes = bos.toByteArray();
 
         postSlackCommandWithFile(arguments, imgBytes, title, FILE_UPLOAD_COMMAND, handle);
         return handle;

--- a/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/TestAbstractSlackSessionImpl.java
+++ b/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/TestAbstractSlackSessionImpl.java
@@ -6,6 +6,8 @@ import com.ullink.slack.simpleslackapi.listeners.SlackConnectedListener;
 import com.ullink.slack.simpleslackapi.replies.*;
 import org.junit.Test;
 
+import java.io.File;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestAbstractSlackSessionImpl
@@ -94,6 +96,26 @@ public class TestAbstractSlackSessionImpl
         @Override
         public SlackMessageHandle<SlackMessageReply> sendFileToUser(String userName, byte[] data, String fileName)
         {
+            return null;
+        }
+
+        @Override
+        public SlackMessageHandle<SlackMessageReply> sendCodeSnippet(SlackChannel channel, String title, String snippet, String language) {
+            return null;
+        }
+
+        @Override
+        public SlackMessageHandle<SlackMessageReply> sendCodeSnippetToUser(SlackUser user, String title, String snippet, String language) {
+            return null;
+        }
+
+        @Override
+        public SlackMessageHandle<SlackMessageReply> sendImage(SlackChannel channel, String title, File img) {
+            return null;
+        }
+
+        @Override
+        public SlackMessageHandle<SlackMessageReply> sendImageToUser(SlackUser user, String title, File img) {
             return null;
         }
 

--- a/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/TestSlackJSONMessageParser.java
+++ b/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/TestSlackJSONMessageParser.java
@@ -13,6 +13,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 
@@ -137,6 +138,26 @@ public class TestSlackJSONMessageParser {
             @Override
             public SlackMessageHandle<SlackMessageReply> sendFileToUser(String userName, byte[] data, String fileName)
             {
+                return null;
+            }
+
+            @Override
+            public SlackMessageHandle<SlackMessageReply> sendCodeSnippet(SlackChannel channel, String title, String snippet, String language) {
+                return null;
+            }
+
+            @Override
+            public SlackMessageHandle<SlackMessageReply> sendCodeSnippetToUser(SlackUser user, String title, String snippet, String language) {
+                return null;
+            }
+
+            @Override
+            public SlackMessageHandle<SlackMessageReply> sendImage(SlackChannel channel, String title, File img) {
+                return null;
+            }
+
+            @Override
+            public SlackMessageHandle<SlackMessageReply> sendImageToUser(SlackUser user, String title, File img) {
                 return null;
             }
 


### PR DESCRIPTION
i've added a method to send an Java Image to a user (with a title)

and another to send a CodeSnippet
here you can define the title, the snippet itself and the language
with the information about the language the so called "fileType" attribute can be added, and slack can highlight that code
https://api.slack.com/types/file#file_types