### PR TITLE
Allow string values to be interpreted as longs

### DIFF
--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/GsonHelper.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/GsonHelper.java
@@ -1,8 +1,12 @@
 package com.ullink.slack.simpleslackapi.impl;
 
+import java.text.NumberFormat;
+import java.text.ParseException;
+
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 
 class GsonHelper
 {
@@ -35,7 +39,25 @@ class GsonHelper
 
     static Long getLongOrDefaultValue(JsonElement jsonElement, Long defaultValue)
     {
-        return jsonElement != null && !jsonElement.isJsonNull() ? (Long) jsonElement.getAsLong() : defaultValue;
+        if (jsonElement == null || jsonElement.isJsonNull()) {
+            return defaultValue;
+        }
+        if (jsonElement instanceof JsonPrimitive) {
+            JsonPrimitive jsonPrimitive = (JsonPrimitive) jsonElement;
+            if (jsonPrimitive.isNumber()) {
+                return jsonPrimitive.getAsNumber().longValue();
+            }
+            String elementAsString = jsonElement.getAsString();
+            if (elementAsString.trim().isEmpty()) {
+                return defaultValue;
+            }
+            try {
+                return NumberFormat.getInstance().parse(elementAsString).longValue();
+            } catch (ParseException e) {
+                return jsonElement.getAsLong();
+            }
+        }
+        return jsonElement.getAsLong();
     }
 
     static String getStringOrDefaultValue(JsonElement jsonElement, String defaultValue)

--- a/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/GsonHelperTest.java
+++ b/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/GsonHelperTest.java
@@ -1,0 +1,87 @@
+package com.ullink.slack.simpleslackapi.impl;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonPrimitive;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GsonHelperTest {
+
+    @Test
+    public void castsStringWithFloatAsLong() {
+
+    	JsonElement jsonElement = new JsonPrimitive("1554055579.006800");
+
+        final Long longOrDefaultValue = GsonHelper.getLongOrDefaultValue(jsonElement, 0L);
+
+        assertThat(longOrDefaultValue).isEqualTo(1554055579L);
+
+    }
+
+    @Test
+    public void castsStringWithIntegerAsLong() {
+
+    	JsonElement jsonElement = new JsonPrimitive("1554055579");
+
+        final Long longOrDefaultValue = GsonHelper.getLongOrDefaultValue(jsonElement, 0L);
+
+        assertThat(longOrDefaultValue).isEqualTo(1554055579L);
+
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void failsOnInvalidString() {
+
+    	JsonElement jsonElement = new JsonPrimitive("hello");
+
+        GsonHelper.getLongOrDefaultValue(jsonElement, 815L);
+
+    }
+
+    @Test
+    public void usesDefaultOnEmptyString() {
+
+    	JsonElement jsonElement = new JsonPrimitive("");
+
+        final Long longOrDefaultValue = GsonHelper.getLongOrDefaultValue(jsonElement, 815L);
+
+        assertThat(longOrDefaultValue).isEqualTo(815L);
+
+    }
+
+
+    @Test
+    public void castsFloatToLong() {
+
+    	JsonElement jsonElement = new JsonPrimitive(47.11);
+
+        final Long longOrDefaultValue = GsonHelper.getLongOrDefaultValue(jsonElement, 0L);
+
+        assertThat(longOrDefaultValue).isEqualTo(47L);
+
+    }
+
+    @Test
+    public void usesDefaultValueOnJsonNull() {
+
+    	JsonElement jsonElement = JsonNull.INSTANCE;
+
+        final Long longOrDefaultValue = GsonHelper.getLongOrDefaultValue(jsonElement, 123L);
+
+        assertThat(longOrDefaultValue).isEqualTo(123L);
+
+    }
+
+    @Test
+    public void takeDefaultValueIfNoJsonElementGiven() {
+
+        final Long longOrDefaultValue = GsonHelper.getLongOrDefaultValue(null, 123456789L);
+
+        assertThat(longOrDefaultValue).isEqualTo(123456789L);
+
+    }
+
+
+}


### PR DESCRIPTION
Hi!

We experience problems with decimal numbers values coming in as string values from Slack.

My change lets the Simple Slack API interpret string values as numbers and extract a long value out of it.

I wrote a test for it. It would be nice if you could merge the pull request and create a release. Many thanks!

Regards

Daniel
