### PR TITLE
fix: LoggerFactory has different implementation in runtime.

### DIFF
--- a/sources/build.gradle
+++ b/sources/build.gradle
@@ -165,6 +165,7 @@ dependencies {
     compile 'org.slf4j:slf4j-api:1.7.7'
     compile 'org.apache.httpcomponents:httpclient:4.5.3'
     compile 'org.apache.httpcomponents:httpmime:4.5.3'
+    compile 'ch.qos.logback:logback-classic:1.2.3'
     compile 'org.threeten:threetenbp:1.3.1'
     compile 'org.glassfish.tyrus.bundles:tyrus-standalone-client:1.13.1'
     compile 'javax.websocket:javax.websocket-api:1.1'


### PR DESCRIPTION
Complete Error: java.lang.LinkageError: loader constraint violation: when resolving method "org.slf4j.impl.StaticLoggerBinder.getLoggerFactory()Lorg/slf4j/ILoggerFactory;" the class loader (instance of jetbrains/buildServer/plugins/classLoaders/PluginStandaloneClassLoader) of the current class, org/slf4j/LoggerFactory, and the class loader (instance of org/apache/catalina/loader/ParallelWebappClassLoader) for the method's defining class, org/slf4j/impl/StaticLoggerBinder, have different Class objects for the type org/slf4j/ILoggerFactory used in the signature

Closes #230 