### PR TITLE
fix: LoggerFactory has different implementation in runtime.

### DIFF
--- a/sources/build.gradle
+++ b/sources/build.gradle
@@ -161,6 +161,7 @@ test {
 }
 
 dependencies {
+    compile 'ch.qos.logback:logback-classic:1.2.3'
     compile 'com.google.code.gson:gson:2.8.0'
     compile 'org.slf4j:slf4j-api:1.7.7'
     compile 'org.apache.httpcomponents:httpclient:4.5.3'


### PR DESCRIPTION
Complete Error: java.lang.LinkageError: loader constraint violation: when resolving method "org.slf4j.impl.StaticLoggerBinder.getLoggerFactory()Lorg/slf4j/ILoggerFactory;" the class loader (instance of jetbrains/buildServer/plugins/classLoaders/PluginStandaloneClassLoader) of the current class, org/slf4j/LoggerFactory, and the class loader (instance of org/apache/catalina/loader/ParallelWebappClassLoader) for the method's defining class, org/slf4j/impl/StaticLoggerBinder, have different Class objects for the type org/slf4j/ILoggerFactory used in the signature

See #230 and #274