### PR TITLE
Make `joinChannel` and `inviteToChannel` methods compatible with new Slack API

### DIFF
--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
@@ -906,7 +906,7 @@ class SlackWebSocketSessionImpl extends AbstractSlackSessionImpl implements Slac
       Map<String, String> arguments = new HashMap<>();
       arguments.put("token", authToken);
       arguments.put("channel", channel.getId());
-      arguments.put("user", user.getId());
+      arguments.put("users", user.getId());
       postSlackCommand(arguments, CONVERSATION.INVITE_COMMAND, handle, SlackChannelReply.class);
       return handle;
     }

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
@@ -874,7 +874,7 @@ class SlackWebSocketSessionImpl extends AbstractSlackSessionImpl implements Slac
         SlackMessageHandle<SlackChannelReply> handle = new SlackMessageHandle<>(getNextMessageId());
         Map<String, String> arguments = new HashMap<>();
         arguments.put("token", authToken);
-        arguments.put("name", channelName);
+        arguments.put("channel", channelName);
         postSlackCommand(arguments, CONVERSATION.JOIN_COMMAND, handle, SlackChannelReply.class);
         return handle;
     }


### PR DESCRIPTION
Make methods compatible with the latest Slack Conversation API: https://api.slack.com/methods.
Updated name of fields to field names from docs.

Please note I have updated only these two methods because we use them, I didn't verify other methods.