### PR TITLE
Member joined listener

### DIFF
--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackSession.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackSession.java
@@ -298,6 +298,10 @@ public interface SlackSession {
     void addPinRemovedListener(PinRemovedListener listener);
   
     void removePinRemovedListener(PinRemovedListener listener);
+    
+    void addSlackMemberJoinedListener(SlackMemberJoinedListener var1);
+
+    void removeSlackMemberJoinedListener(SlackMemberJoinedListener var1);
 
     long getHeartbeat();
 }

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackSessionWrapper.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackSessionWrapper.java
@@ -10,6 +10,7 @@ import com.ullink.slack.simpleslackapi.listeners.SlackChannelArchivedListener;
 import com.ullink.slack.simpleslackapi.listeners.SlackChannelCreatedListener;
 import com.ullink.slack.simpleslackapi.listeners.SlackChannelDeletedListener;
 import com.ullink.slack.simpleslackapi.listeners.SlackChannelJoinedListener;
+import com.ullink.slack.simpleslackapi.listeners.SlackMemberJoinedListener;
 import com.ullink.slack.simpleslackapi.listeners.SlackChannelLeftListener;
 import com.ullink.slack.simpleslackapi.listeners.SlackChannelRenamedListener;
 import com.ullink.slack.simpleslackapi.listeners.SlackChannelUnarchivedListener;

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackSessionWrapper.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackSessionWrapper.java
@@ -725,6 +725,16 @@ public class SlackSessionWrapper implements SlackSession
     {
         delegate.removePinRemovedListener(listener);
     }
+    
+    @Override
+    public void addSlackMemberJoinedListener(SlackMemberJoinedListener listener) {
+        this.delegate.addSlackMemberJoinedListener(listener);
+    }
+    
+    @Override
+    public void removeSlackMemberJoinedListener(SlackMemberJoinedListener listener) {
+        this.delegate.removeSlackMemberJoinedListener(listener);
+    }
 
     @Override public long getHeartbeat()
     {

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/events/EventType.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/events/EventType.java
@@ -22,6 +22,7 @@ public enum EventType
     PIN_ADDED("pin_added"),
     PIN_REMOVED("pin_removed"),
     USER_TYPING("user_typing"),
+    MEMBER_JOINED_CHANNEL("member_joined_channel"),
     OTHER("-");
 
     private static final Map<String, EventType> CODE_MAP = new HashMap<>();

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/events/SlackEventType.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/events/SlackEventType.java
@@ -23,5 +23,6 @@ public enum SlackEventType {
     PIN_REMOVED,
     USER_TYPING,
     UNKNOWN,
-    SLACK_DISCONNECTED
+    SLACK_DISCONNECTED,
+    SLACK_MEMBER_JOINED;
 }

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/events/SlackMemberJoined.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/events/SlackMemberJoined.java
@@ -1,0 +1,48 @@
+package com.ullink.slack.simpleslackapi.events;
+
+import com.ullink.slack.simpleslackapi.SlackChannel;
+import com.ullink.slack.simpleslackapi.SlackUser;
+import lombok.NonNull;
+
+
+public class SlackMemberJoined implements SlackEvent {
+
+    @NonNull
+    private SlackUser user;
+    @NonNull
+    private SlackChannel slackChannel;
+
+
+    public SlackEventType getEventType() {
+        return SlackEventType.SLACK_MEMBER_JOINED;
+    }
+
+    public SlackMemberJoined(SlackUser user, SlackChannel slackChannel) {
+        if (slackChannel == null) {
+            throw new NullPointerException("slackChannel is marked non-null but is null");
+        } else {
+            this.slackChannel = slackChannel;
+            this.user = user;
+        }
+    }
+
+    public SlackChannel getChannel() {
+        return this.slackChannel;
+    }
+
+    public SlackUser getUser() {
+        return this.user;
+    }
+
+    public void setChannel(SlackChannel slackChannel) {
+        this.slackChannel = slackChannel;
+    }
+
+    public void setUser(SlackUser user) {
+        this.user=user;
+    }
+
+    public String toString() {
+        return "A new Slack Member Joined" + this.slackChannel + ", user=" + this.user;
+    }
+}

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/AbstractSlackSessionImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/AbstractSlackSessionImpl.java
@@ -38,6 +38,7 @@ abstract class AbstractSlackSessionImpl implements SlackSession
     protected final List<PresenceChangeListener>         presenceChangeListener    = new CopyOnWriteArrayList<>();
     protected final List<SlackDisconnectedListener>      slackDisconnectedListener = new CopyOnWriteArrayList<>();
     protected final List<UserTypingListener>             userTypingListener        = new CopyOnWriteArrayList<>();
+    protected final List<SlackMemberJoinedListener>      slackMemberJoinedListener = new CopyOnWriteArrayList();
 
     static final SlackChatConfiguration            DEFAULT_CONFIGURATION    = SlackChatConfiguration.getConfiguration().asUser();
     static final boolean                           DEFAULT_UNFURL           = true;
@@ -506,5 +507,15 @@ abstract class AbstractSlackSessionImpl implements SlackSession
     @Override
     public void removeUserTypingListener(UserTypingListener listener) {
         userTypingListener.remove(listener);
+    }
+    
+    @Override
+    public void addSlackMemberJoinedListener(SlackMemberJoinedListener listener) {
+        this.slackMemberJoinedListener.add(listener);
+    }
+
+    @Override
+    public void removeSlackMemberJoinedListener(SlackMemberJoinedListener listener) {
+        this.slackMemberJoinedListener.remove(listener);
     }
 }

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackJSONMessageParser.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackJSONMessageParser.java
@@ -96,9 +96,20 @@ class SlackJSONMessageParser {
                 return extractPinRemovedEvent(slackSession, obj);
             case USER_TYPING:
                 return extractUserTypingEvent(slackSession, obj);
+	    case MEMBER_JOINED_CHANNEL:
+                return extractMemberJoinedChannelEvent(slackSession, obj);
             default:
                 return new UnknownEvent(obj.toString());
         }
+    }
+	
+    private static SlackMemberJoined extractMemberJoinedChannelEvent(SlackSession slackSession, JsonObject obj) {
+        String channelId = GsonHelper.getStringOrNull(obj.get("channel"));
+        SlackChannel slackChannel = slackSession.findChannelById(channelId);
+        String userId = GsonHelper.getStringOrNull(obj.get("user"));
+        SlackUser user = slackSession.findUserById(userId);
+        System.out.println("channelId" + channelId+"user"+user);
+        return new SlackMemberJoined(user, slackChannel);
     }
 
     private static SlackChannelJoined extractChannelJoinedEvent(SlackSession slackSession, JsonObject obj)

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
@@ -286,6 +286,9 @@ class SlackWebSocketSessionImpl extends AbstractSlackSessionImpl implements Slac
                 case USER_TYPING:
                     dispatchImpl((UserTyping) event, userTypingListener);
                     break;
+		case SLACK_MEMBER_JOINED:
+                    this.dispatchImpl((SlackMemberJoined)event, SlackWebSocketSessionImpl.this.slackMemberJoinedListener);
+                    break;
                 default:
 		    //sloppy fix for ClassCastException from ? to UnknownEvent Error.
 		    if (event instanceof UnknownEvent) {

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/listeners/SlackMemberJoinedListener.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/listeners/SlackMemberJoinedListener.java
@@ -1,0 +1,6 @@
+package com.ullink.slack.simpleslackapi.listeners;
+
+import com.ullink.slack.simpleslackapi.events.SlackMemberJoined;
+
+public interface SlackMemberJoinedListener extends SlackEventListener<SlackMemberJoined> {
+}


### PR DESCRIPTION
#261 this is the member_joined_channel event of Slack, which notifies whenever any member(self, another user, or bot) joins the channel.

ChannelJoinedListener only works when a member itself (bot) joins the channel.